### PR TITLE
feat(webp): add webp support (when using sharp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A webpack loader for responsive images. Creates multiple images from one source 
 npm install responsive-loader jimp --save-dev
 ```
 
-Per default, responsive-loader uses [jimp](https://github.com/oliver-moran/jimp) to transform images. which needs to be installed alongside responsive-loader. Because jimp is written entirely in JavaScript and doesn't have any native dependencies it will work anywhere. The main drawback is that it's pretty slow.
+Per default, responsive-loader uses [jimp](https://github.com/oliver-moran/jimp) to transform images. which needs to be installed alongside responsive-loader. Because jimp is written entirely in JavaScript and doesn't have any native dependencies it will work anywhere. The main drawback is that it's pretty slow and it doesn't support webp encoding.
 
 ### With sharp
 
@@ -121,7 +121,7 @@ ReactDOM.render(
 | `max` | `integer` | | See `min` above |
 | `steps` | `integer` |`4` | Configure the number of images generated between `min` and `max` (inclusive) |
 | `quality` | `integer` | `85` | JPEG compression quality |
-| `format` | `string` | *original format* | Either `png` or `jpg`; use to convert to another format |
+| `format` | `string` | *original format* | One of `png`, `jpg` or `webp`(only with sharp); use to convert to another format. |
 | `placeholder` | `boolean` | `false` | A true or false value to specify wether to output a placeholder image as a data URI |
 | `placeholderSize` | `integer` | `40` | A number value specifying the width of the placeholder image, if enabled with the option above |
 | `adapter` | `Adapter` | JIMP | Specify which adapter to use. Can only be specified in the loader options. |

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,15 @@ const loaderUtils = require('loader-utils');
 const MIMES = {
   'jpg': 'image/jpeg',
   'jpeg': 'image/jpeg',
-  'png': 'image/png'
+  'png': 'image/png',
+  'webp': 'image/webp',
 };
 
 const EXTS = {
   'image/jpeg': 'jpg',
-  'image/png': 'png'
+  'image/png': 'png',
+  'image/webp': 'webp',
+
 };
 
 type Config = {
@@ -27,7 +30,7 @@ type Config = {
   background: string | number | void,
   placeholder: string | boolean | void,
   adapter: ?Function,
-  format: 'png' | 'jpg' | 'jpeg',
+  format: 'png' | 'jpg' | 'jpeg' | 'webp',
   disable: ?boolean,
 };
 
@@ -59,9 +62,12 @@ module.exports = function loader(content: Buffer) {
     }
   }
 
-  const name = (config.name || '[hash]-[width].[ext]').replace(/\[ext\]/ig, ext);
-
   const adapter: Function = config.adapter || require('./adapters/jimp');
+  if (!config.adapter && (mime === MIMES['webp'])) {
+    return loaderCallback(new Error('JIMP does not support webp encoding, use sharp adapter.'));
+  }
+
+  const name = (config.name || '[hash]-[width].[ext]').replace(/\[ext\]/ig, ext);
   const loaderContext: any = this;
 
   // The config that is passed to the adatpers

--- a/test/sharp/build/__snapshots__/test.js.snap
+++ b/test/sharp/build/__snapshots__/test.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`convert from jpg to webp 1`] = `
+Object {
+  "height": 450,
+  "images": Array [
+    Object {
+      "height": 450,
+      "path": "foobar/6060dab00c4595a4a88a27192398bcf5-500.webp",
+      "width": 500,
+    },
+    Object {
+      "height": 675,
+      "path": "foobar/b876032f02904c9a2f93d9116471ff13-750.webp",
+      "width": 750,
+    },
+    Object {
+      "height": 900,
+      "path": "foobar/c94d312c65954f4c967fbaeb9ac4f000-1000.webp",
+      "width": 1000,
+    },
+  ],
+  "placeholder": undefined,
+  "src": "foobar/6060dab00c4595a4a88a27192398bcf5-500.webp",
+  "srcSet": "foobar/6060dab00c4595a4a88a27192398bcf5-500.webp 500w,foobar/b876032f02904c9a2f93d9116471ff13-750.webp 750w,foobar/c94d312c65954f4c967fbaeb9ac4f000-1000.webp 1000w",
+  "toString": [Function],
+  "width": 500,
+}
+`;
+
+exports[`convert from png to webp 1`] = `
+Object {
+  "height": 580,
+  "images": Array [
+    Object {
+      "height": 580,
+      "path": "foobar/d42dd47dda0e1fb5e29a49ed75374bf6-500.webp",
+      "width": 500,
+    },
+    Object {
+      "height": 595,
+      "path": "foobar/a01387960c0fdae534983959778dfb75-513.webp",
+      "width": 513,
+    },
+  ],
+  "placeholder": undefined,
+  "src": "foobar/d42dd47dda0e1fb5e29a49ed75374bf6-500.webp",
+  "srcSet": "foobar/d42dd47dda0e1fb5e29a49ed75374bf6-500.webp 500w,foobar/a01387960c0fdae534983959778dfb75-513.webp 513w",
+  "toString": [Function],
+  "width": 500,
+}
+`;
+
 exports[`disable 1`] = `
 Object {
   "images": Array [
@@ -21,18 +72,18 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
+      "path": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 900,
-      "path": "foobar/c0e86e74879bf9156e7b1e92b38f293c-1000.jpg",
+      "path": "foobar/32eef0247bb077de607da3d1f021d138-1000.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
-  "srcSet": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg 500w,foobar/c0e86e74879bf9156e7b1e92b38f293c-1000.jpg 1000w",
+  "src": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
+  "srcSet": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg 500w,foobar/32eef0247bb077de607da3d1f021d138-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -44,13 +95,13 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
+      "path": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
       "width": 500,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
-  "srcSet": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg 500w",
+  "src": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
+  "srcSet": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg 500w",
   "toString": [Function],
   "width": 500,
 }
@@ -62,23 +113,23 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/test/953a024b44e6d2a7ea721eb06626b913-500x450.jpg",
+      "path": "foobar/test/31316a4269319e254e9c8c4726f23e2a-500x450.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/test/a011c4fb35cda2d2c8cd4384711ce65e-750x675.jpg",
+      "path": "foobar/test/e22aaf470a7a7c6ffb2260200c9219c8-750x675.jpg",
       "width": 750,
     },
     Object {
       "height": 900,
-      "path": "foobar/test/c0e86e74879bf9156e7b1e92b38f293c-1000x900.jpg",
+      "path": "foobar/test/32eef0247bb077de607da3d1f021d138-1000x900.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/test/953a024b44e6d2a7ea721eb06626b913-500x450.jpg",
-  "srcSet": "foobar/test/953a024b44e6d2a7ea721eb06626b913-500x450.jpg 500w,foobar/test/a011c4fb35cda2d2c8cd4384711ce65e-750x675.jpg 750w,foobar/test/c0e86e74879bf9156e7b1e92b38f293c-1000x900.jpg 1000w",
+  "src": "foobar/test/31316a4269319e254e9c8c4726f23e2a-500x450.jpg",
+  "srcSet": "foobar/test/31316a4269319e254e9c8c4726f23e2a-500x450.jpg 500w,foobar/test/e22aaf470a7a7c6ffb2260200c9219c8-750x675.jpg 750w,foobar/test/32eef0247bb077de607da3d1f021d138-1000x900.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -90,13 +141,13 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg",
+      "path": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg",
       "width": 100,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg",
-  "srcSet": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg 100w",
+  "src": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg",
+  "srcSet": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg 100w",
   "toString": [Function],
   "width": 100,
 }
@@ -108,18 +159,18 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg",
+      "path": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg",
       "width": 100,
     },
     Object {
       "height": 180,
-      "path": "foobar/8640f0494e614246b96b1d949a09aabe-200.jpg",
+      "path": "foobar/51212ab63bb2e2a6ebcd47e416d9ddd5-200.jpg",
       "width": 200,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg",
-  "srcSet": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg 100w,foobar/8640f0494e614246b96b1d949a09aabe-200.jpg 200w",
+  "src": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg",
+  "srcSet": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg 100w,foobar/51212ab63bb2e2a6ebcd47e416d9ddd5-200.jpg 200w",
   "toString": [Function],
   "width": 100,
 }
@@ -131,18 +182,18 @@ Object {
   "images": Array [
     Object {
       "height": 580,
-      "path": "foobar/dfeecbec599f476d3a0215bb6e7f3dd6-500.png",
+      "path": "foobar/d42dd47dda0e1fb5e29a49ed75374bf6-500.png",
       "width": 500,
     },
     Object {
       "height": 595,
-      "path": "foobar/711285969b04c54a921259f638713eaf-513.png",
+      "path": "foobar/a01387960c0fdae534983959778dfb75-513.png",
       "width": 513,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/dfeecbec599f476d3a0215bb6e7f3dd6-500.png",
-  "srcSet": "foobar/dfeecbec599f476d3a0215bb6e7f3dd6-500.png 500w,foobar/711285969b04c54a921259f638713eaf-513.png 513w",
+  "src": "foobar/d42dd47dda0e1fb5e29a49ed75374bf6-500.png",
+  "srcSet": "foobar/d42dd47dda0e1fb5e29a49ed75374bf6-500.png 500w,foobar/a01387960c0fdae534983959778dfb75-513.png 513w",
   "toString": [Function],
   "width": 500,
 }
@@ -154,18 +205,18 @@ Object {
   "images": Array [
     Object {
       "height": 580,
-      "path": "foobar/52440c55e0faa5afd07962bc15e4eb82-500.jpg",
+      "path": "foobar/3b785e0cf3c48bbc4a709a66986ec10e-500.jpg",
       "width": 500,
     },
     Object {
       "height": 595,
-      "path": "foobar/064787a0e33e6aba3b8f8417d05447c0-513.jpg",
+      "path": "foobar/149a3d69bc16ee3b406a4958420dc6f8-513.jpg",
       "width": 513,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/52440c55e0faa5afd07962bc15e4eb82-500.jpg",
-  "srcSet": "foobar/52440c55e0faa5afd07962bc15e4eb82-500.jpg 500w,foobar/064787a0e33e6aba3b8f8417d05447c0-513.jpg 513w",
+  "src": "foobar/3b785e0cf3c48bbc4a709a66986ec10e-500.jpg",
+  "srcSet": "foobar/3b785e0cf3c48bbc4a709a66986ec10e-500.jpg 500w,foobar/149a3d69bc16ee3b406a4958420dc6f8-513.jpg 513w",
   "toString": [Function],
   "width": 500,
 }
@@ -177,13 +228,13 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
+      "path": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
       "width": 500,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
-  "srcSet": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg 500w",
+  "src": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
+  "srcSet": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg 500w",
   "toString": [Function],
   "width": 500,
 }
@@ -195,23 +246,23 @@ Object {
   "images": Array [
     Object {
       "height": 540,
-      "path": "foobar/2af17e12f0375a11dd41544eb39e7d1d-600.jpg",
+      "path": "foobar/01168b3ce0529e3b728756e48bf8512e-600.jpg",
       "width": 600,
     },
     Object {
       "height": 630,
-      "path": "foobar/bf06fb2a494b7477a73c7ec05625c3bc-700.jpg",
+      "path": "foobar/0649b5b1b66f3609b9f1084b816c2802-700.jpg",
       "width": 700,
     },
     Object {
       "height": 720,
-      "path": "foobar/bf55049b4b942dfd0388b7396cea413f-800.jpg",
+      "path": "foobar/34eb182358c4c30f9262ecac22cc5ab0-800.jpg",
       "width": 800,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/2af17e12f0375a11dd41544eb39e7d1d-600.jpg",
-  "srcSet": "foobar/2af17e12f0375a11dd41544eb39e7d1d-600.jpg 600w,foobar/bf06fb2a494b7477a73c7ec05625c3bc-700.jpg 700w,foobar/bf55049b4b942dfd0388b7396cea413f-800.jpg 800w",
+  "src": "foobar/01168b3ce0529e3b728756e48bf8512e-600.jpg",
+  "srcSet": "foobar/01168b3ce0529e3b728756e48bf8512e-600.jpg 600w,foobar/0649b5b1b66f3609b9f1084b816c2802-700.jpg 700w,foobar/34eb182358c4c30f9262ecac22cc5ab0-800.jpg 800w",
   "toString": [Function],
   "width": 600,
 }
@@ -223,28 +274,28 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg",
+      "path": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg",
       "width": 100,
     },
     Object {
       "height": 150,
-      "path": "foobar/d86220978e22280502676420b56a1454-167.jpg",
+      "path": "foobar/ce6d807877acb0db226ae8a54baf176c-167.jpg",
       "width": 167,
     },
     Object {
       "height": 211,
-      "path": "foobar/1b1b3464b8c8ee3649f93af92616860e-234.jpg",
+      "path": "foobar/2ed82e5ef0591bb80e721d6c82155307-234.jpg",
       "width": 234,
     },
     Object {
       "height": 270,
-      "path": "foobar/0f324a0de1e2536e830b1fcdfe180f70-300.jpg",
+      "path": "foobar/9b164ff4b53969c2efc15af5614d2845-300.jpg",
       "width": 300,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg",
-  "srcSet": "foobar/08070e9ab95245b811d3c0e64e833545-100.jpg 100w,foobar/d86220978e22280502676420b56a1454-167.jpg 167w,foobar/1b1b3464b8c8ee3649f93af92616860e-234.jpg 234w,foobar/0f324a0de1e2536e830b1fcdfe180f70-300.jpg 300w",
+  "src": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg",
+  "srcSet": "foobar/f3b25440ddcd15bf8d134645a5942dcc-100.jpg 100w,foobar/ce6d807877acb0db226ae8a54baf176c-167.jpg 167w,foobar/2ed82e5ef0591bb80e721d6c82155307-234.jpg 234w,foobar/9b164ff4b53969c2efc15af5614d2845-300.jpg 300w",
   "toString": [Function],
   "width": 100,
 }
@@ -256,28 +307,28 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
+      "path": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 600,
-      "path": "foobar/b0ed6bbd99877351fa6186d69e6691db-667.jpg",
+      "path": "foobar/21cbfa574946fda32b8ca811b659d5ec-667.jpg",
       "width": 667,
     },
     Object {
       "height": 751,
-      "path": "foobar/afc0583941b419b2f3d725572ec58c5c-834.jpg",
+      "path": "foobar/b9d644735c53c4a52a7aa223997f4dde-834.jpg",
       "width": 834,
     },
     Object {
       "height": 900,
-      "path": "foobar/c0e86e74879bf9156e7b1e92b38f293c-1000.jpg",
+      "path": "foobar/32eef0247bb077de607da3d1f021d138-1000.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
-  "srcSet": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg 500w,foobar/b0ed6bbd99877351fa6186d69e6691db-667.jpg 667w,foobar/afc0583941b419b2f3d725572ec58c5c-834.jpg 834w,foobar/c0e86e74879bf9156e7b1e92b38f293c-1000.jpg 1000w",
+  "src": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
+  "srcSet": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg 500w,foobar/21cbfa574946fda32b8ca811b659d5ec-667.jpg 667w,foobar/b9d644735c53c4a52a7aa223997f4dde-834.jpg 834w,foobar/32eef0247bb077de607da3d1f021d138-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -289,23 +340,23 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
+      "path": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/a011c4fb35cda2d2c8cd4384711ce65e-750.jpg",
+      "path": "foobar/e22aaf470a7a7c6ffb2260200c9219c8-750.jpg",
       "width": 750,
     },
     Object {
       "height": 900,
-      "path": "foobar/c0e86e74879bf9156e7b1e92b38f293c-1000.jpg",
+      "path": "foobar/32eef0247bb077de607da3d1f021d138-1000.jpg",
       "width": 1000,
     },
   ],
-  "placeholder": "data:image/jpeg;base64,/9j/2wBDAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx7/2wBDAQUFBQcGBw4ICA4eFBEUHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh7/wAARCAAkACgDASIAAhEBAxEB/8QAHAAAAgEFAQAAAAAAAAAAAAAAAAcGAQIDBAgF/8QALRAAAQMDAgMHBAMAAAAAAAAAAQIDBAAFEQYhBxIxCBMiQWFxgSMyUaFCUpH/xAAYAQADAQEAAAAAAAAAAAAAAAAAAQMCBP/EAB0RAAMAAgIDAAAAAAAAAAAAAAABAgMRBBIhIjH/2gAMAwEAAhEDEQA/APLvfZ1ak3BoWq5RYEIq+qe7WXEp/CRnCvckVpDszuourDidUoehBRLqXIZDmPIAAkH1yRXSEqRHhxHpcp1DMdlBW44rYISOpNJzU3aJ0nbpKmbRb5d35TjvgoMtk+mQSR8Cr1ML6TTZHr52ZrRJaK7bfpMSR6sBTZ+M5H+1GHuzpq2yzYs6zXSBclIz3rS/oH4J2I98U0NAcedPajvLVruFtfs70jZp1bwcaKuuCcZT7mmpFudqmLCYlxhSSo8oDUhC8n8bGk4i1o1N1DTQndE8Hlols3DVa2Hu7IUmE14kFQ/ur+Q9Bsf1RTqKAR5n3oojDELSRTLyMmWu1MSer+GuqZthmvat4jSpcCIwt1TZUUN+EZBWNh8kGubEwS85hgh4bYCBnOem3Wu9n4EaRHWxIjoeQ8OVbbg5kKB8iDsahF34WRJeroepYLseDIjkBaER0lDgH24SMYUPzWax78omqEJw24W3i7CbIecTbJUCR3IakpUFc3KCfbrTc4RcNntL6uReTLZ7hLCg82FFRcfVkcw2GEjb91L7/Y7y8hTCHAUyAQt5tsBwEDYk9fLGa2+GNnvcDTDTGoH3JElDznI64QVrbJ8JVjYHrSUewdnolQUlW++PMUUFjlBIOaK6DBlSkZJqxY8QwTRRSYFGlEpUSc71mcAAA8j1oopoCg3GfM9aKKKAP//Z",
-  "src": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
-  "srcSet": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg 500w,foobar/a011c4fb35cda2d2c8cd4384711ce65e-750.jpg 750w,foobar/c0e86e74879bf9156e7b1e92b38f293c-1000.jpg 1000w",
+  "placeholder": "data:image/jpeg;base64,/9j/2wBDAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx7/2wBDAQUFBQcGBw4ICA4eFBEUHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh7/wAARCAAkACgDASIAAhEBAxEB/8QAHAAAAgICAwAAAAAAAAAAAAAAAAcDBgEIAgQF/8QALRAAAQMDAgUEAQQDAAAAAAAAAQIDBAAFEQYhBxITMUEIIlFhFBYycYIjUoH/xAAYAQADAQEAAAAAAAAAAAAAAAAAAQIDBP/EABwRAAMAAwADAAAAAAAAAAAAAAABAgMRMQQSIv/aAAwDAQACEQMRAD8A8m9+nVEie0LRcYcCEVZeV01lxCfhKc4UfskYrpK9M0hN0YcRqpl2EFEupdhkOY8AYVg/ecVsm86xGjOyZDjbTDKStxxWyUJAyST4ApRam9QmjLZJUxa4sy8lO3VawyyT9KVuf5xXQ5ldM02Va+ema0SWiu23+TEkb/uYSps/1yCP+GqvI9OWr7PKiT7PdbddHGzl1pWWD/UnIO3zimroPjzpnUd5ZtU23ybO/JPKy446lxoq8AkAFOfkjFNVmXBfI6EuK7zHlHI6hWT8bHvScRSKmqlpoSejeDkhcpqbq1bBbQeb8FhXMFEf7r8j6Hf5op4FAIxuf5opRgxwtJGuTysuR7piT1Zw81/dLJL/AFZxGW/b48dbi22/8ba+VJPvwACNu5zWtX4ZcVltSXUAA5R7sjtv8VvrLt0OXDdiy2EvtSElDrLnuQsHwQdjS/vXCSNI1fB1FakwICoxSHWBGHScSn9pCU4wobfXb4qbjfDJVoRHDPhne74ubJSpMB+2vpb6ckFKubl5u3jYim1wj4ZzNNa1YvTj8cMIbUuUOfm6j5CgAkYHtHMDk/dXe+2m9LCkISgqle1yS01hzmA9pJByPjJ7VPwstuoGNOdPUbq3pCZLnTfWkBTrefaSB284pKPoPZ6LgCle4yB5FFY6BTkg7UVuQSoTuTk7VxcyDkE0UUnwDDKioKKt6lVskDPeiiqQANxzHue9FFFAH//Z",
+  "src": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
+  "srcSet": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg 500w,foobar/e22aaf470a7a7c6ffb2260200c9219c8-750.jpg 750w,foobar/32eef0247bb077de607da3d1f021d138-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -317,23 +368,23 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
+      "path": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/a011c4fb35cda2d2c8cd4384711ce65e-750.jpg",
+      "path": "foobar/e22aaf470a7a7c6ffb2260200c9219c8-750.jpg",
       "width": 750,
     },
     Object {
       "height": 900,
-      "path": "foobar/c0e86e74879bf9156e7b1e92b38f293c-1000.jpg",
+      "path": "foobar/32eef0247bb077de607da3d1f021d138-1000.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg",
-  "srcSet": "foobar/953a024b44e6d2a7ea721eb06626b913-500.jpg 500w,foobar/a011c4fb35cda2d2c8cd4384711ce65e-750.jpg 750w,foobar/c0e86e74879bf9156e7b1e92b38f293c-1000.jpg 1000w",
+  "src": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg",
+  "srcSet": "foobar/31316a4269319e254e9c8c4726f23e2a-500.jpg 500w,foobar/e22aaf470a7a7c6ffb2260200c9219c8-750.jpg 750w,foobar/32eef0247bb077de607da3d1f021d138-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }

--- a/test/sharp/index.js
+++ b/test/sharp/index.js
@@ -68,3 +68,13 @@ test('override min and max with size', () => {
   const output = require('../cat-1000.jpg?minmax&size=100');
   expect(output).toMatchSnapshot();
 });
+
+test('convert from jpg to webp', () => {
+  const output = require('../cat-1000.jpg?format=webp');
+  expect(output).toMatchSnapshot();
+});
+
+test('convert from png to webp', () => {
+  const output = require('../cat-transparent.png?format=webp');
+  expect(output).toMatchSnapshot();
+});


### PR DESCRIPTION
Add webp support.

I wanted to test the throw when you're using jimp but couldn't figure out how. The thrown error is handled and re-thrown by webpack which is run prior to jest.