### PR TITLE
Add emitFile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ ReactDOM.render(
 | `placeholderSize` | `integer` | `40` | A number value specifying the width of the placeholder image, if enabled with the option above |
 | `adapter` | `Adapter` | JIMP | Specify which adapter to use. Can only be specified in the loader options. |
 | `disable` | `boolean` | `false` | Disable processing of images by this loader (useful in development). `srcSet` and other attributes will still be generated but only for the original size. Note that the `width` and `height` attributes will both be set to `100` but the image will retain its original dimensions. |
+| `emitFile` | `boolean` | `true` | If `true`, emits a file (writes a file to the filesystem). If `false`, the loader will still return a object with the public URI but will not emit the file. It is often useful to disable this option for server-side packages. |
 
 #### Adapter-specific options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "responsive-loader",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A webpack loader for responsive images",
   "main": "lib/index.js",
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ type Config = {
   adapter: ?Function,
   format: 'png' | 'jpg' | 'jpeg',
   disable: ?boolean,
+  emitFile: ?boolean,
 };
 
 module.exports = function loader(content: Buffer) {
@@ -60,6 +61,8 @@ module.exports = function loader(content: Buffer) {
   }
 
   const name = (config.name || '[hash]-[width].[ext]').replace(/\[ext\]/ig, ext);
+
+  const emitFile = config.emitFile !== false;
 
   const adapter: Function = config.adapter || require('./adapters/jimp');
   const loaderContext: any = this;
@@ -98,7 +101,7 @@ module.exports = function loader(content: Buffer) {
     })
       .replace(/\[width\]/ig, '100')
       .replace(/\[height\]/ig, '100');
-    loaderContext.emitFile(f, content);
+    if (emitFile) loaderContext.emitFile(f, content);
     const p = '__webpack_public_path__ + ' + JSON.stringify(f);
     return loaderCallback(null, 'module.exports = {srcSet:' + p + ',images:[{path:' + p + ',width:100,height:100}],src: ' + p + ',toString:function(){return ' + p + '}};');
   }
@@ -111,7 +114,7 @@ module.exports = function loader(content: Buffer) {
     .replace(/\[width\]/ig, width)
     .replace(/\[height\]/ig, height);
 
-    loaderContext.emitFile(fileName, data);
+    if (emitFile) loaderContext.emitFile(fileName, data);
 
     return {
       src: '__webpack_public_path__ + ' + JSON.stringify(fileName + ' ' + width + 'w'),

--- a/test/jimp/build/__snapshots__/test.js.snap
+++ b/test/jimp/build/__snapshots__/test.js.snap
@@ -15,6 +15,24 @@ Object {
 }
 `;
 
+exports[`doesn't emit file 1`] = `
+Object {
+  "height": 225,
+  "images": Array [
+    Object {
+      "height": 225,
+      "path": "foobar/bb31f8607bd93fb40fc894d9c0070ea4-250.jpg",
+      "width": 250,
+    },
+  ],
+  "placeholder": undefined,
+  "src": "foobar/bb31f8607bd93fb40fc894d9c0070ea4-250.jpg",
+  "srcSet": "foobar/bb31f8607bd93fb40fc894d9c0070ea4-250.jpg 250w",
+  "toString": [Function],
+  "width": 250,
+}
+`;
+
 exports[`multiple sizes 1`] = `
 Object {
   "height": 450,

--- a/test/jimp/index.js
+++ b/test/jimp/index.js
@@ -19,6 +19,11 @@ test('disable', () => {
   expect(multi).toMatchSnapshot();
 });
 
+test('doesn\'t emit file', () => {
+  const multi = require('../cat-1000.jpg?emitFile=false&sizes[]=250');
+  expect(multi).toMatchSnapshot();
+});
+
 test('output should be relative to context', () => {
   const multi = require('../cat-1000.jpg?name=[path][hash]-[width]x[height].[ext]&context=./');
   expect(multi).toMatchSnapshot();

--- a/test/sharp/build/__snapshots__/test.js.snap
+++ b/test/sharp/build/__snapshots__/test.js.snap
@@ -15,6 +15,24 @@ Object {
 }
 `;
 
+exports[`doesn't emit file 1`] = `
+Object {
+  "height": 225,
+  "images": Array [
+    Object {
+      "height": 225,
+      "path": "foobar/50c66a01e4e6eb726827ab1e40e9646c-250.jpg",
+      "width": 250,
+    },
+  ],
+  "placeholder": undefined,
+  "src": "foobar/50c66a01e4e6eb726827ab1e40e9646c-250.jpg",
+  "srcSet": "foobar/50c66a01e4e6eb726827ab1e40e9646c-250.jpg 250w",
+  "toString": [Function],
+  "width": 250,
+}
+`;
+
 exports[`multiple sizes 1`] = `
 Object {
   "height": 450,

--- a/test/sharp/index.js
+++ b/test/sharp/index.js
@@ -19,6 +19,11 @@ test('disable', () => {
   expect(multi).toMatchSnapshot();
 });
 
+test('doesn\'t emit file', () => {
+  const multi = require('../cat-1000.jpg?emitFile=false&sizes[]=250');
+  expect(multi).toMatchSnapshot();
+});
+
 test('output should be relative to context', () => {
   const multi = require('../cat-1000.jpg?name=[path][hash]-[width]x[height].[ext]&context=./');
   expect(multi).toMatchSnapshot();


### PR DESCRIPTION
Added this option like file-loader.

If `true`, emits a file (writes a file to the filesystem). If `false`, the loader will still return a object with the public URI but will not emit the file. It is often useful to disable this option for server-side packages.