### PR TITLE
Jimp

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-react": "^5.2.2",
     "flow-bin": "^0.85.0",
     "jest": "^20.0.4",
-    "jimp": "^0.2.21",
+    "jimp": "^0.6.0",
     "sharp": "^0.18.2",
     "webpack": "^3.1.0"
   },

--- a/src/adapters/jimp.js
+++ b/src/adapters/jimp.js
@@ -12,7 +12,7 @@ module.exports = (imagePath: string) => {
       new Promise((resolve, reject) => {
         readImage.then(image => {
           image.clone()
-            .resize(width, jimp.AUTO)
+            .resize(width, jimp.AUTO, jimp.RESIZE_NEAREST_NEIGHBOR)
             .quality(options.quality)
             .background(parseInt(options.background, 16) || 0xFFFFFFFF)
             .getBuffer(mime, function(err, data) { // eslint-disable-line func-names

--- a/src/adapters/jimp.js
+++ b/src/adapters/jimp.js
@@ -12,7 +12,7 @@ module.exports = (imagePath: string) => {
       new Promise((resolve, reject) => {
         readImage.then(image => {
           image.clone()
-            .resize(width, jimp.AUTO, jimp.RESIZE_NEAREST_NEIGHBOR)
+            .resize(width, jimp.AUTO, jimp.RESIZE_BEZIER)
             .quality(options.quality)
             .background(parseInt(options.background, 16) || 0xFFFFFFFF)
             .getBuffer(mime, function(err, data) { // eslint-disable-line func-names

--- a/test/jimp/build/__snapshots__/test.js.snap
+++ b/test/jimp/build/__snapshots__/test.js.snap
@@ -21,18 +21,18 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+      "path": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
       "width": 500,
     },
     Object {
       "height": 900,
-      "path": "foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg",
+      "path": "foobar/6801db19d07d82551852bf6f258f62bf-1000.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
-  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
+  "srcSet": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg 500w,foobar/6801db19d07d82551852bf6f258f62bf-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -44,13 +44,13 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+      "path": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
       "width": 500,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
-  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w",
+  "src": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
+  "srcSet": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg 500w",
   "toString": [Function],
   "width": 500,
 }
@@ -62,23 +62,23 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/img/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+      "path": "foobar/img/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/img/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg",
+      "path": "foobar/img/63986dc24badace0c2676f9b60800d95-750.jpg",
       "width": 750,
     },
     Object {
       "height": 900,
-      "path": "foobar/img/654f812ac2833fdf5dae880cceefa8c6-1000.jpg",
+      "path": "foobar/img/6801db19d07d82551852bf6f258f62bf-1000.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/img/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
-  "srcSet": "foobar/img/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/img/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg 750w,foobar/img/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "foobar/img/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
+  "srcSet": "foobar/img/0429a2ab6f91e9c14d31fd68587f7460-500.jpg 500w,foobar/img/63986dc24badace0c2676f9b60800d95-750.jpg 750w,foobar/img/6801db19d07d82551852bf6f258f62bf-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -90,23 +90,23 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/test/0e1d4cd5f6d282f2b72c682e56f7002a-500x450.jpg",
+      "path": "foobar/test/0429a2ab6f91e9c14d31fd68587f7460-500x450.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/test/52f7d960dfb880f2ad06e6a72d14c1d3-750x675.jpg",
+      "path": "foobar/test/63986dc24badace0c2676f9b60800d95-750x675.jpg",
       "width": 750,
     },
     Object {
       "height": 900,
-      "path": "foobar/test/654f812ac2833fdf5dae880cceefa8c6-1000x900.jpg",
+      "path": "foobar/test/6801db19d07d82551852bf6f258f62bf-1000x900.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/test/0e1d4cd5f6d282f2b72c682e56f7002a-500x450.jpg",
-  "srcSet": "foobar/test/0e1d4cd5f6d282f2b72c682e56f7002a-500x450.jpg 500w,foobar/test/52f7d960dfb880f2ad06e6a72d14c1d3-750x675.jpg 750w,foobar/test/654f812ac2833fdf5dae880cceefa8c6-1000x900.jpg 1000w",
+  "src": "foobar/test/0429a2ab6f91e9c14d31fd68587f7460-500x450.jpg",
+  "srcSet": "foobar/test/0429a2ab6f91e9c14d31fd68587f7460-500x450.jpg 500w,foobar/test/63986dc24badace0c2676f9b60800d95-750x675.jpg 750w,foobar/test/6801db19d07d82551852bf6f258f62bf-1000x900.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -118,13 +118,13 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
+      "path": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg",
       "width": 100,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
-  "srcSet": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg 100w",
+  "src": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg",
+  "srcSet": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg 100w",
   "toString": [Function],
   "width": 100,
 }
@@ -136,18 +136,18 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
+      "path": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg",
       "width": 100,
     },
     Object {
       "height": 180,
-      "path": "foobar/8cf5144d1a53539a63ab0c857480e0d4-200.jpg",
+      "path": "foobar/8009d43adef2cbd1af44e1959b1af387-200.jpg",
       "width": 200,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
-  "srcSet": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg 100w,foobar/8cf5144d1a53539a63ab0c857480e0d4-200.jpg 200w",
+  "src": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg",
+  "srcSet": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg 100w,foobar/8009d43adef2cbd1af44e1959b1af387-200.jpg 200w",
   "toString": [Function],
   "width": 100,
 }
@@ -159,18 +159,18 @@ Object {
   "images": Array [
     Object {
       "height": 580,
-      "path": "foobar/664746997a52e6e2d19e8ec18f3cb1e3-500.png",
+      "path": "foobar/4481956c9e3a909fc355403f35f3e150-500.png",
       "width": 500,
     },
     Object {
       "height": 595,
-      "path": "foobar/cb22e95242175e627b7160dcafc23f71-513.png",
+      "path": "foobar/a9e996a9f55911b83718f26a19327b54-513.png",
       "width": 513,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/664746997a52e6e2d19e8ec18f3cb1e3-500.png",
-  "srcSet": "foobar/664746997a52e6e2d19e8ec18f3cb1e3-500.png 500w,foobar/cb22e95242175e627b7160dcafc23f71-513.png 513w",
+  "src": "foobar/4481956c9e3a909fc355403f35f3e150-500.png",
+  "srcSet": "foobar/4481956c9e3a909fc355403f35f3e150-500.png 500w,foobar/a9e996a9f55911b83718f26a19327b54-513.png 513w",
   "toString": [Function],
   "width": 500,
 }
@@ -182,18 +182,18 @@ Object {
   "images": Array [
     Object {
       "height": 580,
-      "path": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg",
+      "path": "foobar/553f6bceed78e1c1b11be188b0ba271e-500.jpg",
       "width": 500,
     },
     Object {
       "height": 595,
-      "path": "foobar/9affb0e18b367d321029cb1d539517fd-513.jpg",
+      "path": "foobar/130f1f85892eda69981a73cc638b55d7-513.jpg",
       "width": 513,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg",
-  "srcSet": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg 500w,foobar/9affb0e18b367d321029cb1d539517fd-513.jpg 513w",
+  "src": "foobar/553f6bceed78e1c1b11be188b0ba271e-500.jpg",
+  "srcSet": "foobar/553f6bceed78e1c1b11be188b0ba271e-500.jpg 500w,foobar/130f1f85892eda69981a73cc638b55d7-513.jpg 513w",
   "toString": [Function],
   "width": 500,
 }
@@ -205,18 +205,18 @@ Object {
   "images": Array [
     Object {
       "height": 580,
-      "path": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg",
+      "path": "foobar/553f6bceed78e1c1b11be188b0ba271e-500.jpg",
       "width": 500,
     },
     Object {
       "height": 595,
-      "path": "foobar/9affb0e18b367d321029cb1d539517fd-513.jpg",
+      "path": "foobar/130f1f85892eda69981a73cc638b55d7-513.jpg",
       "width": 513,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg",
-  "srcSet": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg 500w,foobar/9affb0e18b367d321029cb1d539517fd-513.jpg 513w",
+  "src": "foobar/553f6bceed78e1c1b11be188b0ba271e-500.jpg",
+  "srcSet": "foobar/553f6bceed78e1c1b11be188b0ba271e-500.jpg 500w,foobar/130f1f85892eda69981a73cc638b55d7-513.jpg 513w",
   "toString": [Function],
   "width": 500,
 }
@@ -228,23 +228,23 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "public/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+      "path": "public/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "public/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg",
+      "path": "public/63986dc24badace0c2676f9b60800d95-750.jpg",
       "width": 750,
     },
     Object {
       "height": 900,
-      "path": "public/654f812ac2833fdf5dae880cceefa8c6-1000.jpg",
+      "path": "public/6801db19d07d82551852bf6f258f62bf-1000.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "public/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
-  "srcSet": "public/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,public/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg 750w,public/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "public/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
+  "srcSet": "public/0429a2ab6f91e9c14d31fd68587f7460-500.jpg 500w,public/63986dc24badace0c2676f9b60800d95-750.jpg 750w,public/6801db19d07d82551852bf6f258f62bf-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -256,13 +256,13 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+      "path": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
       "width": 500,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
-  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w",
+  "src": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
+  "srcSet": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg 500w",
   "toString": [Function],
   "width": 500,
 }
@@ -274,23 +274,23 @@ Object {
   "images": Array [
     Object {
       "height": 540,
-      "path": "foobar/a9bb9ae4b53063c3fe3276866ccf95ea-600.jpg",
+      "path": "foobar/c0e905fb89fdd0083a2c70080df10f0c-600.jpg",
       "width": 600,
     },
     Object {
       "height": 630,
-      "path": "foobar/b7c2874f8b37be3ff1f29f211ad478eb-700.jpg",
+      "path": "foobar/b702c730461974bc4f9a626580bf6f0a-700.jpg",
       "width": 700,
     },
     Object {
       "height": 720,
-      "path": "foobar/4d88294cf2a6ec2dc7481dea13d95bd5-800.jpg",
+      "path": "foobar/be35f3271a55ffcc20768788809855c4-800.jpg",
       "width": 800,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/a9bb9ae4b53063c3fe3276866ccf95ea-600.jpg",
-  "srcSet": "foobar/a9bb9ae4b53063c3fe3276866ccf95ea-600.jpg 600w,foobar/b7c2874f8b37be3ff1f29f211ad478eb-700.jpg 700w,foobar/4d88294cf2a6ec2dc7481dea13d95bd5-800.jpg 800w",
+  "src": "foobar/c0e905fb89fdd0083a2c70080df10f0c-600.jpg",
+  "srcSet": "foobar/c0e905fb89fdd0083a2c70080df10f0c-600.jpg 600w,foobar/b702c730461974bc4f9a626580bf6f0a-700.jpg 700w,foobar/be35f3271a55ffcc20768788809855c4-800.jpg 800w",
   "toString": [Function],
   "width": 600,
 }
@@ -302,28 +302,28 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
+      "path": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg",
       "width": 100,
     },
     Object {
       "height": 150,
-      "path": "foobar/c40223dc5a41265ea2a203cc37e8a28c-167.jpg",
+      "path": "foobar/41c3f613507c807be81bdb3a4be55237-167.jpg",
       "width": 167,
     },
     Object {
       "height": 211,
-      "path": "foobar/5b37861aa24d9355ed43047d739bbc98-234.jpg",
+      "path": "foobar/547dcf9850202380d7c05248197ea410-234.jpg",
       "width": 234,
     },
     Object {
       "height": 270,
-      "path": "foobar/abd18ed265be7dede2a8e9f71e2738ca-300.jpg",
+      "path": "foobar/4f87da871e132c05ef0f14353e777d99-300.jpg",
       "width": 300,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
-  "srcSet": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg 100w,foobar/c40223dc5a41265ea2a203cc37e8a28c-167.jpg 167w,foobar/5b37861aa24d9355ed43047d739bbc98-234.jpg 234w,foobar/abd18ed265be7dede2a8e9f71e2738ca-300.jpg 300w",
+  "src": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg",
+  "srcSet": "foobar/1c8750011e160ec41d57e15e4bd904f3-100.jpg 100w,foobar/41c3f613507c807be81bdb3a4be55237-167.jpg 167w,foobar/547dcf9850202380d7c05248197ea410-234.jpg 234w,foobar/4f87da871e132c05ef0f14353e777d99-300.jpg 300w",
   "toString": [Function],
   "width": 100,
 }
@@ -335,28 +335,28 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+      "path": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
       "width": 500,
     },
     Object {
       "height": 600,
-      "path": "foobar/5d85ed69da0bf864735cb5f3cc08ef50-667.jpg",
+      "path": "foobar/b72d937a7b455f797b29d64062f273ce-667.jpg",
       "width": 667,
     },
     Object {
       "height": 751,
-      "path": "foobar/2386936912b74b421b9e54283fb6b66b-834.jpg",
+      "path": "foobar/d0c44e8e628b7a3c2c79ab38c0f964b2-834.jpg",
       "width": 834,
     },
     Object {
       "height": 900,
-      "path": "foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg",
+      "path": "foobar/6801db19d07d82551852bf6f258f62bf-1000.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
-  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/5d85ed69da0bf864735cb5f3cc08ef50-667.jpg 667w,foobar/2386936912b74b421b9e54283fb6b66b-834.jpg 834w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
+  "srcSet": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg 500w,foobar/b72d937a7b455f797b29d64062f273ce-667.jpg 667w,foobar/d0c44e8e628b7a3c2c79ab38c0f964b2-834.jpg 834w,foobar/6801db19d07d82551852bf6f258f62bf-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -368,23 +368,23 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+      "path": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg",
+      "path": "foobar/63986dc24badace0c2676f9b60800d95-750.jpg",
       "width": 750,
     },
     Object {
       "height": 900,
-      "path": "foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg",
+      "path": "foobar/6801db19d07d82551852bf6f258f62bf-1000.jpg",
       "width": 1000,
     },
   ],
-  "placeholder": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx4BBQUFBwYHDggIDh4UERQeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHv/AABEIACQAKAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AOf1z9neV5UTQLixtIWZRJJLJKWRc84BzuOOcZHPGe9bOkuhmpStZmbefs1a6moW/wBj8R6fPaFsTtLC8Mipxnao3BjjPBYdueeF7JjUi/rX7MkU0Rl0/wASeTPliQbQmNvbG/I578/Sn7JBzM5G5/Z8+IGjfYb+w+w6pcLN++t7aYIUX1DSbQwIyD0Iz0PUZzotxaNaVXkmpdj0Dwb8JNavbyObxNEunWSMd9tHMrSynAwMrlVU9znPGMDOa5KWBle8z1cRmkeW1LfufQQCIpZtiqoyWPGBXqHhnmnin43+AdC1H7Et3catKpbzG06MSImACAXJVWznjaW6HOKh1EhpNkPhH45eC/EOsQ6aYtQ02S4bZDJdRp5TNuAVdyscE5HUYzkZ7kVSLE4yPUiq7s4yenSrAj2DkZ79OlAHjmo+D/jPrGmS2WteO7eKBgTL9kVYi3B+XdHErbfXnnuKxaqPQq8ep8xz2YEpiUq64Kq4wcgHnGP59OetYJ3Rrsdd8O/h9rXiW6um03Fu1hJCwa4AA+bLgn+98oXjH8XYdW43TEpWaPWPhv8ADfWdN+JttrVzBGbIkzXZk2jy3BYoFwxLEkRsSBgZIySDlwg21ccpWWnU9+yjnIOMHvXWYGdqGnW+oadc2V6ZJILuJoZo/MK7lYFSMg8ZBPI5qQPM/FvwbtL3xBp+raFpuk2ItmVZ7YwCOGWMHPRBgt2OQcg4PA5zlT6opS7nR6vY6nbzyXAtrdZ73ZDJcxRNuLjITcV5PXbkgYz7YpTTtcUR/wAK4vEM+k3a6+C0kd46xXHl7RKnH8OTjB4zk85HGCA6aeqY5W6Hb+UychuO1akj1GX9MHtTARyQTg4HpUsBImLsd2DQgJV4TaOhqkAvVck9eDQB/9k=",
-  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
-  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg 750w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "placeholder": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx4BBQUFBwYHDggIDh4UERQeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHv/AABEIACQAKAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AMnW/wBnZLi/iGlaha2NmW/et5bmRF9FXOG+pIxW7pLoZ8ztZlJv2aJ11SGRPFMctmGzIslmQ+OwGGIPv0qfZDUi7rn7NGk3MRfTtduLS4Pcwhoz/wAByMfnVOmg5mcvc/s5+LNHubW+0jVLHUpIzmWJgYT/AMBySDx64rKpQcotG1Gt7Oal2O98GfB6drqK98VyQmNDuFlCchj/ALbensOvrXPRwVneZ34jM+ZctNfM9vnlgtbaW5uZI4YIlLvI/CqoGST6V6J5B5H4m/aC8HaZcvBpdtd6uyHBlT91ET7FuT/3zis3USGosk8CfHjw34i1iLS72wuNImuDtikeUSRFvQnAIz64xQqi6g4s9UhvLG4x5F3bShjtBSRWyfTjvWl0IkKA8H8jQB4p4t+HvjzU9DvD4r+ILTWFvA8jxxjyo22jPz4Cgjjqc1jKM31LTiuh81myLv8AuyJEAB+T5sjpz6VhujTZnffDX4aa1rjXtwrLYzafMsey5BVtxGfw4IpyjdEqVmetfCb4aXnhzxrBrUlxD5KRs10C+4yTEMPl4HA3A59QaqnB8ybCUlY9tBV+RkDuMV1GRnXen2l5Zy213As8U6lJIZPmRweCCDwancDz/WfhJaz+LrHxDpSWNgbcqJYBbDy3VfukKuMMOP09Kh09boaemps65pWslXSNI83PElxHHh9wHBJByOBjPapmmwRZ+F2m6/D4dMfiKV5rhLmQRzsAGkjzwSB05zVU07ajlbodd5JXJB4rToSSqvOcmmAx8qeCalgELFgxbmmgJW4UDPWmADkZ7nrQB//Z",
+  "src": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
+  "srcSet": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg 500w,foobar/63986dc24badace0c2676f9b60800d95-750.jpg 750w,foobar/6801db19d07d82551852bf6f258f62bf-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -396,23 +396,23 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+      "path": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg",
+      "path": "foobar/63986dc24badace0c2676f9b60800d95-750.jpg",
       "width": 750,
     },
     Object {
       "height": 900,
-      "path": "foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg",
+      "path": "foobar/6801db19d07d82551852bf6f258f62bf-1000.jpg",
       "width": 1000,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
-  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg 750w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg",
+  "srcSet": "foobar/0429a2ab6f91e9c14d31fd68587f7460-500.jpg 500w,foobar/63986dc24badace0c2676f9b60800d95-750.jpg 750w,foobar/6801db19d07d82551852bf6f258f62bf-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }

--- a/test/jimp/build/__snapshots__/test.js.snap
+++ b/test/jimp/build/__snapshots__/test.js.snap
@@ -21,7 +21,7 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
+      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
       "width": 500,
     },
     Object {
@@ -31,8 +31,8 @@ Object {
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
-  "srcSet": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg 500w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -44,13 +44,13 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
+      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
       "width": 500,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
-  "srcSet": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg 500w",
+  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w",
   "toString": [Function],
   "width": 500,
 }
@@ -62,12 +62,12 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/img/8b1d7d4d688417adcd8603807f44314e-500.jpg",
+      "path": "foobar/img/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/img/0884176ab3183a7809908a89735a26f2-750.jpg",
+      "path": "foobar/img/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg",
       "width": 750,
     },
     Object {
@@ -77,8 +77,8 @@ Object {
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/img/8b1d7d4d688417adcd8603807f44314e-500.jpg",
-  "srcSet": "foobar/img/8b1d7d4d688417adcd8603807f44314e-500.jpg 500w,foobar/img/0884176ab3183a7809908a89735a26f2-750.jpg 750w,foobar/img/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "foobar/img/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+  "srcSet": "foobar/img/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/img/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg 750w,foobar/img/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -90,12 +90,12 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/test/8b1d7d4d688417adcd8603807f44314e-500x450.jpg",
+      "path": "foobar/test/0e1d4cd5f6d282f2b72c682e56f7002a-500x450.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/test/0884176ab3183a7809908a89735a26f2-750x675.jpg",
+      "path": "foobar/test/52f7d960dfb880f2ad06e6a72d14c1d3-750x675.jpg",
       "width": 750,
     },
     Object {
@@ -105,8 +105,8 @@ Object {
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/test/8b1d7d4d688417adcd8603807f44314e-500x450.jpg",
-  "srcSet": "foobar/test/8b1d7d4d688417adcd8603807f44314e-500x450.jpg 500w,foobar/test/0884176ab3183a7809908a89735a26f2-750x675.jpg 750w,foobar/test/654f812ac2833fdf5dae880cceefa8c6-1000x900.jpg 1000w",
+  "src": "foobar/test/0e1d4cd5f6d282f2b72c682e56f7002a-500x450.jpg",
+  "srcSet": "foobar/test/0e1d4cd5f6d282f2b72c682e56f7002a-500x450.jpg 500w,foobar/test/52f7d960dfb880f2ad06e6a72d14c1d3-750x675.jpg 750w,foobar/test/654f812ac2833fdf5dae880cceefa8c6-1000x900.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -118,13 +118,13 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg",
+      "path": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
       "width": 100,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg",
-  "srcSet": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg 100w",
+  "src": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
+  "srcSet": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg 100w",
   "toString": [Function],
   "width": 100,
 }
@@ -136,18 +136,18 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg",
+      "path": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
       "width": 100,
     },
     Object {
       "height": 180,
-      "path": "foobar/47b5a3359ed0722769a9888e5d22054a-200.jpg",
+      "path": "foobar/8cf5144d1a53539a63ab0c857480e0d4-200.jpg",
       "width": 200,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg",
-  "srcSet": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg 100w,foobar/47b5a3359ed0722769a9888e5d22054a-200.jpg 200w",
+  "src": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
+  "srcSet": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg 100w,foobar/8cf5144d1a53539a63ab0c857480e0d4-200.jpg 200w",
   "toString": [Function],
   "width": 100,
 }
@@ -159,18 +159,18 @@ Object {
   "images": Array [
     Object {
       "height": 580,
-      "path": "foobar/09ebde7f5c9dce3efa4f410ad72b4c3f-500.png",
+      "path": "foobar/664746997a52e6e2d19e8ec18f3cb1e3-500.png",
       "width": 500,
     },
     Object {
       "height": 595,
-      "path": "foobar/f677a14b0ff11b0fa0788e2a52884e1c-513.png",
+      "path": "foobar/cb22e95242175e627b7160dcafc23f71-513.png",
       "width": 513,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/09ebde7f5c9dce3efa4f410ad72b4c3f-500.png",
-  "srcSet": "foobar/09ebde7f5c9dce3efa4f410ad72b4c3f-500.png 500w,foobar/f677a14b0ff11b0fa0788e2a52884e1c-513.png 513w",
+  "src": "foobar/664746997a52e6e2d19e8ec18f3cb1e3-500.png",
+  "srcSet": "foobar/664746997a52e6e2d19e8ec18f3cb1e3-500.png 500w,foobar/cb22e95242175e627b7160dcafc23f71-513.png 513w",
   "toString": [Function],
   "width": 500,
 }
@@ -182,7 +182,7 @@ Object {
   "images": Array [
     Object {
       "height": 580,
-      "path": "foobar/f0ca0d1b9ad58dfea6e8bc88b51a95d7-500.jpg",
+      "path": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg",
       "width": 500,
     },
     Object {
@@ -192,8 +192,8 @@ Object {
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/f0ca0d1b9ad58dfea6e8bc88b51a95d7-500.jpg",
-  "srcSet": "foobar/f0ca0d1b9ad58dfea6e8bc88b51a95d7-500.jpg 500w,foobar/9affb0e18b367d321029cb1d539517fd-513.jpg 513w",
+  "src": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg",
+  "srcSet": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg 500w,foobar/9affb0e18b367d321029cb1d539517fd-513.jpg 513w",
   "toString": [Function],
   "width": 500,
 }
@@ -205,7 +205,7 @@ Object {
   "images": Array [
     Object {
       "height": 580,
-      "path": "foobar/f0ca0d1b9ad58dfea6e8bc88b51a95d7-500.jpg",
+      "path": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg",
       "width": 500,
     },
     Object {
@@ -215,8 +215,8 @@ Object {
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/f0ca0d1b9ad58dfea6e8bc88b51a95d7-500.jpg",
-  "srcSet": "foobar/f0ca0d1b9ad58dfea6e8bc88b51a95d7-500.jpg 500w,foobar/9affb0e18b367d321029cb1d539517fd-513.jpg 513w",
+  "src": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg",
+  "srcSet": "foobar/8f3205961f8059ed1a5f6ab169a6037c-500.jpg 500w,foobar/9affb0e18b367d321029cb1d539517fd-513.jpg 513w",
   "toString": [Function],
   "width": 500,
 }
@@ -228,12 +228,12 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "public/8b1d7d4d688417adcd8603807f44314e-500.jpg",
+      "path": "public/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "public/0884176ab3183a7809908a89735a26f2-750.jpg",
+      "path": "public/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg",
       "width": 750,
     },
     Object {
@@ -243,8 +243,8 @@ Object {
     },
   ],
   "placeholder": undefined,
-  "src": "public/8b1d7d4d688417adcd8603807f44314e-500.jpg",
-  "srcSet": "public/8b1d7d4d688417adcd8603807f44314e-500.jpg 500w,public/0884176ab3183a7809908a89735a26f2-750.jpg 750w,public/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "public/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+  "srcSet": "public/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,public/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg 750w,public/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -256,13 +256,13 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
+      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
       "width": 500,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
-  "srcSet": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg 500w",
+  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w",
   "toString": [Function],
   "width": 500,
 }
@@ -274,23 +274,23 @@ Object {
   "images": Array [
     Object {
       "height": 540,
-      "path": "foobar/52dba34908ff9d9ed720ad3c51e5b651-600.jpg",
+      "path": "foobar/a9bb9ae4b53063c3fe3276866ccf95ea-600.jpg",
       "width": 600,
     },
     Object {
       "height": 630,
-      "path": "foobar/86240606919a79fc3de5a7dbe5a97d87-700.jpg",
+      "path": "foobar/b7c2874f8b37be3ff1f29f211ad478eb-700.jpg",
       "width": 700,
     },
     Object {
       "height": 720,
-      "path": "foobar/f794cdac765d222d40585d283c49bddc-800.jpg",
+      "path": "foobar/4d88294cf2a6ec2dc7481dea13d95bd5-800.jpg",
       "width": 800,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/52dba34908ff9d9ed720ad3c51e5b651-600.jpg",
-  "srcSet": "foobar/52dba34908ff9d9ed720ad3c51e5b651-600.jpg 600w,foobar/86240606919a79fc3de5a7dbe5a97d87-700.jpg 700w,foobar/f794cdac765d222d40585d283c49bddc-800.jpg 800w",
+  "src": "foobar/a9bb9ae4b53063c3fe3276866ccf95ea-600.jpg",
+  "srcSet": "foobar/a9bb9ae4b53063c3fe3276866ccf95ea-600.jpg 600w,foobar/b7c2874f8b37be3ff1f29f211ad478eb-700.jpg 700w,foobar/4d88294cf2a6ec2dc7481dea13d95bd5-800.jpg 800w",
   "toString": [Function],
   "width": 600,
 }
@@ -302,28 +302,28 @@ Object {
   "images": Array [
     Object {
       "height": 90,
-      "path": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg",
+      "path": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
       "width": 100,
     },
     Object {
       "height": 150,
-      "path": "foobar/86a90430aa0b6a9c877ba2e7560f348d-167.jpg",
+      "path": "foobar/c40223dc5a41265ea2a203cc37e8a28c-167.jpg",
       "width": 167,
     },
     Object {
       "height": 211,
-      "path": "foobar/84c4601d3d3e2fda34fb8cdd4743be8b-234.jpg",
+      "path": "foobar/5b37861aa24d9355ed43047d739bbc98-234.jpg",
       "width": 234,
     },
     Object {
       "height": 270,
-      "path": "foobar/652ca9fc84422fc0712297fe218d4bd7-300.jpg",
+      "path": "foobar/abd18ed265be7dede2a8e9f71e2738ca-300.jpg",
       "width": 300,
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg",
-  "srcSet": "foobar/bb319add04d2ce76039de36229ccfde4-100.jpg 100w,foobar/86a90430aa0b6a9c877ba2e7560f348d-167.jpg 167w,foobar/84c4601d3d3e2fda34fb8cdd4743be8b-234.jpg 234w,foobar/652ca9fc84422fc0712297fe218d4bd7-300.jpg 300w",
+  "src": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg",
+  "srcSet": "foobar/5f4f9a15b85bf6eaba444a880ab97b87-100.jpg 100w,foobar/c40223dc5a41265ea2a203cc37e8a28c-167.jpg 167w,foobar/5b37861aa24d9355ed43047d739bbc98-234.jpg 234w,foobar/abd18ed265be7dede2a8e9f71e2738ca-300.jpg 300w",
   "toString": [Function],
   "width": 100,
 }
@@ -335,17 +335,17 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
+      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 600,
-      "path": "foobar/24b8e1d900d0f26e0ac60c406f85c0ce-667.jpg",
+      "path": "foobar/5d85ed69da0bf864735cb5f3cc08ef50-667.jpg",
       "width": 667,
     },
     Object {
       "height": 751,
-      "path": "foobar/63dc049fe958369666cc1793fca64800-834.jpg",
+      "path": "foobar/2386936912b74b421b9e54283fb6b66b-834.jpg",
       "width": 834,
     },
     Object {
@@ -355,8 +355,8 @@ Object {
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
-  "srcSet": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg 500w,foobar/24b8e1d900d0f26e0ac60c406f85c0ce-667.jpg 667w,foobar/63dc049fe958369666cc1793fca64800-834.jpg 834w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/5d85ed69da0bf864735cb5f3cc08ef50-667.jpg 667w,foobar/2386936912b74b421b9e54283fb6b66b-834.jpg 834w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -368,12 +368,12 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
+      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/0884176ab3183a7809908a89735a26f2-750.jpg",
+      "path": "foobar/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg",
       "width": 750,
     },
     Object {
@@ -382,9 +382,9 @@ Object {
       "width": 1000,
     },
   ],
-  "placeholder": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx4BBQUFBwYHDggIDh4UERQeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHv/AABEIACQAKAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AMnW/wBnaO4v4hpWo2tjZFv3reWxkRfRVzhvqSMe9bukuhnzO1mUm/ZomXVIZF8Uxy2YbMiyWZD47AYYg/pU+yGpF3XP2aNIuYi+na7cWlwe5hDRn/gORj86p0kHMzl7j9nPxZo9za32karY6lJGcyxMDCf+A5JB49cVlUoOUWjajW9nNS7HfeDPg9ObqK+8VyQsiHcLKE5DEf327j2HX1rCjgrO8zvxGZuS5aa+Z7dPNBa20tzcyRwwRKXkkfhVUDJJ9K9A8g8i8TftB+D9MuXg0u1utXZODKn7mIn2LfMf++cVm6iQ1FkvgT48eG/EWsRaXe2E+kTXB2xSPKJIi3oTgEZ9cYoVVdQcWeqQ3thcY+z3dtNuO0bJFbJ9OD1rS6ESFAeOfoaAPFPFvw98dalod43iv4hNNYW8DyPHH+7jbaCfnwACOOpzWMozfUtOK6HzWbIu/wC7IlQAH5PmyOnPpWG6L2Z33w1+Geta217cBlsJ9PmEWy5Uq27GfTjginKN0JSsz1v4S/DS78N+NINakuIfJSNmuQX3GSYhh8vA4AYHPrmqpwfMmwlJWPbAVfkZA7iuoyM+70+0u7SW2u4FninUpJDJ8yOD1BB4NTuB5/rHwltZ/F9j4h0pbKxNsQJIBbDy3VfukKMYYcfp6VDp63Q0+5sa5pOssrxxqmbniS4jjw+4Dgkg5HAxntUzTYIs/C7Tdfg8O+X4ilea4S5kEczABpI88EgdO/4VVNO2o5W6HXeQVyQcitCSVVGc5NMBr5DcE1LASJiwYtzzTQErcKBng0wAdM9z1oA//9k=",
-  "src": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
-  "srcSet": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg 500w,foobar/0884176ab3183a7809908a89735a26f2-750.jpg 750w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "placeholder": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEPERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx4BBQUFBwYHDggIDh4UERQeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHv/AABEIACQAKAMBEQACEQEDEQH/xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAABfQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+gEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIygQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqCg4SFhoeIiYqSk5SVlpeYmZqio6Slpqeoqaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2dri4+Tl5ufo6ery8/T19vf4+fr/2gAMAwEAAhEDEQA/AOf1z9neV5UTQLixtIWZRJJLJKWRc84BzuOOcZHPGe9bOkuhmpStZmbefs1a6moW/wBj8R6fPaFsTtLC8Mipxnao3BjjPBYdueeF7JjUi/rX7MkU0Rl0/wASeTPliQbQmNvbG/I578/Sn7JBzM5G5/Z8+IGjfYb+w+w6pcLN++t7aYIUX1DSbQwIyD0Iz0PUZzotxaNaVXkmpdj0Dwb8JNavbyObxNEunWSMd9tHMrSynAwMrlVU9znPGMDOa5KWBle8z1cRmkeW1LfufQQCIpZtiqoyWPGBXqHhnmnin43+AdC1H7Et3catKpbzG06MSImACAXJVWznjaW6HOKh1EhpNkPhH45eC/EOsQ6aYtQ02S4bZDJdRp5TNuAVdyscE5HUYzkZ7kVSLE4yPUiq7s4yenSrAj2DkZ79OlAHjmo+D/jPrGmS2WteO7eKBgTL9kVYi3B+XdHErbfXnnuKxaqPQq8ep8xz2YEpiUq64Kq4wcgHnGP59OetYJ3Rrsdd8O/h9rXiW6um03Fu1hJCwa4AA+bLgn+98oXjH8XYdW43TEpWaPWPhv8ADfWdN+JttrVzBGbIkzXZk2jy3BYoFwxLEkRsSBgZIySDlwg21ccpWWnU9+yjnIOMHvXWYGdqGnW+oadc2V6ZJILuJoZo/MK7lYFSMg8ZBPI5qQPM/FvwbtL3xBp+raFpuk2ItmVZ7YwCOGWMHPRBgt2OQcg4PA5zlT6opS7nR6vY6nbzyXAtrdZ73ZDJcxRNuLjITcV5PXbkgYz7YpTTtcUR/wAK4vEM+k3a6+C0kd46xXHl7RKnH8OTjB4zk85HGCA6aeqY5W6Hb+UychuO1akj1GX9MHtTARyQTg4HpUsBImLsd2DQgJV4TaOhqkAvVck9eDQB/9k=",
+  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg 750w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }
@@ -396,12 +396,12 @@ Object {
   "images": Array [
     Object {
       "height": 450,
-      "path": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
+      "path": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
       "width": 500,
     },
     Object {
       "height": 675,
-      "path": "foobar/0884176ab3183a7809908a89735a26f2-750.jpg",
+      "path": "foobar/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg",
       "width": 750,
     },
     Object {
@@ -411,8 +411,8 @@ Object {
     },
   ],
   "placeholder": undefined,
-  "src": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg",
-  "srcSet": "foobar/8b1d7d4d688417adcd8603807f44314e-500.jpg 500w,foobar/0884176ab3183a7809908a89735a26f2-750.jpg 750w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
+  "src": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg",
+  "srcSet": "foobar/0e1d4cd5f6d282f2b72c682e56f7002a-500.jpg 500w,foobar/52f7d960dfb880f2ad06e6a72d14c1d3-750.jpg 750w,foobar/654f812ac2833fdf5dae880cceefa8c6-1000.jpg 1000w",
   "toString": [Function],
   "width": 500,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,266 @@
 # yarn lockfile v1
 
 
+"@babel/polyfill@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0.tgz#c8ff65c9ec3be6a1ba10113ebd40e8750fb90bff"
+  integrity sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.11.1"
+
+"@jimp/bmp@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/bmp/-/bmp-0.6.0.tgz#6eb3ad441ed3f1418a32a89a4244285914b2a15c"
+  integrity sha512-zZOcVT1zK/1QL5a7qirkzPPgDKB1ianER7pBdpR2J71vx/g8MnrPbL3h/jEVPxjdci2Hph/VWhc/oLBtTbqO8w==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    bmp-js "^0.1.0"
+    core-js "^2.5.7"
+
+"@jimp/core@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/core/-/core-0.6.0.tgz#a366988f6b339db9a8e2ce532fa90f017ea7f02f"
+  integrity sha512-ngAkyCLtX7buc2QyFy0ql/j4R2wGYQVsVhW2G3Y0GVAAklRIFIUYpyNKrqs228xA8f2O6XStbDStFlYkt7uNeg==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    any-base "^1.1.0"
+    buffer "^5.2.0"
+    core-js "^2.5.7"
+    exif-parser "^0.1.12"
+    file-type "^9.0.0"
+    load-bmfont "^1.3.1"
+    mkdirp "0.5.1"
+    phin "^2.9.1"
+    pixelmatch "^4.0.2"
+    tinycolor2 "^1.4.1"
+
+"@jimp/custom@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/custom/-/custom-0.6.0.tgz#acccc248701c20007ea6f4972a1aeb55e2c2d7fb"
+  integrity sha512-+YZIWhf03Rfbi+VPbHomKInu3tcntF/aij/JrIJd1QZq13f8m3mRNxakXupiL18KH0C8BPNDk8RiwFX+HaOw3A==
+  dependencies:
+    "@jimp/core" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/gif@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/gif/-/gif-0.6.0.tgz#f4cd1d6671465790282d50117f8e00748aff1037"
+  integrity sha512-aWQ02P0ymTN1eh0BVsY+84wMdb/QeiVpCNQZl9y50cRnpuMM8TTmF/ZdCEBDiTRFcwXzHsqBXcLwEcYp3X2lTw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+    omggif "^1.0.9"
+
+"@jimp/jpeg@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/jpeg/-/jpeg-0.6.0.tgz#9061f495f19a7f9039e39380faef8a6004b57c36"
+  integrity sha512-quYb+lM4h57jQvr2q9dEIkc0laTljws4dunIdFhJRfa5UlNL5mHInk8h5MxyALo0mZdT07TAcxiDHw5QXZ28JQ==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+    jpeg-js "^0.3.4"
+
+"@jimp/plugin-blit@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-blit/-/plugin-blit-0.6.0.tgz#fe8495dfdefff72da9923682626d668c1126ad75"
+  integrity sha512-LjiCa+8OT2fgmvBpZt0ogurg/eu5kB8ZFWDRwHPcf8i+058sZC20dar/qrjVd5Knssq4ynjb5oAHsGuJq16Rqw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-blur@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-blur/-/plugin-blur-0.6.0.tgz#6537943782775c1a3d656c6a17c6bbe64fe16f65"
+  integrity sha512-/vjGcEiHda6OLTCYqXPFkfSTbL+RatZoGcp1vewcWqChUccn9QVINTlxB7nEI/3Nb/i7KdhOPNEQh1k6q6QXsw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-color@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-color/-/plugin-color-0.6.0.tgz#a2f36d8484e50ad7c8f5a0d484bfc4f5d536dfb0"
+  integrity sha512-mvDeAwN8ZpDkOaABMJ0w9zUzo9OOtu1qvvPkSirXDTMiXt1nsbfz8BoeoD7nU2MFhQj5MiGjH65UDnsH5ZzYuw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+    tinycolor2 "^1.4.1"
+
+"@jimp/plugin-contain@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-contain/-/plugin-contain-0.6.0.tgz#174c94777db264dcb0796f515b84d0497428959f"
+  integrity sha512-gPHnoQkDztMbvnTVo01BaMoM/hhDJdeJ7FRToD4p4Qvdor4V0I6NXtjOeUPXfD94miTgh/UTyJDqeG4GZzi4sA==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-cover@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-cover/-/plugin-cover-0.6.0.tgz#8f61e5fbdab709099c5f39a9398f62447093a6e2"
+  integrity sha512-iv9lA2v3qv+x3eaTThtyzFg+hO8/pSnM8NBymC5OlpSJnR54aWi7BVFXLJAF27T4EZyXko432PVul2IdY3BEPw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-crop@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-crop/-/plugin-crop-0.6.0.tgz#ef093b94327d3a2f642223a078861a96614367f5"
+  integrity sha512-YftdmFZ2YnZDYyBulkStCt2MZbKKfbjytkE+6i3Djk2b/Rfryg5xjgzVnAumCRQJhVPukexrnc2V7KKbEgx7mQ==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-displace@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-displace/-/plugin-displace-0.6.0.tgz#d96c66fc54283a9865a2e8044adebd54f093b366"
+  integrity sha512-kkva5Fy3r7J7QmiqYQ5c9NeUKKkN7+KSfCGsZ6tkRHK4REMIXhQO/OnJN8XG6RReV29O6QykdyeTXDiHUDiROw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-dither@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-dither/-/plugin-dither-0.6.0.tgz#c7470480fd6d23a67188c2270ac3e9494a051d61"
+  integrity sha512-ILSG7bl3SOqmcIa9C4nBvs0h0E0ObnMbeKWUZiNuz6i0OAlbxryiIfU4j0UVQD5XqT9ksC5mviVNrvOMw4SZLw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-flip@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-flip/-/plugin-flip-0.6.0.tgz#cdfbc6059e156912a50c41cb5f617a4693f793d2"
+  integrity sha512-MXGGwABjERvfqVadEzJuVAmbsEQfjxXD0O/mMBegU1Qh7/JmnKAVplQCnojsMPxUdao/FKZjQqOnB/j4LLJtOQ==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-gaussian@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-gaussian/-/plugin-gaussian-0.6.0.tgz#fc97468e67dccd9872d1fb177e4bbc5e8e2944ec"
+  integrity sha512-RUsBCyj6Ukxgn/TU8v6c6WRbSFqKM0iknLVqDkKIuiOyJB7ougv66fqomh/i/h3ihIkEnf50BuO0c3ovrczfvw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-invert@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-invert/-/plugin-invert-0.6.0.tgz#da4879a41cc0c12110c2bf5e63524b07819c3524"
+  integrity sha512-zTCqK8el6eqcNKAxw0y57gHBFgxygI5iM8dQDPyqsvVWO71i8XII7ubnJhEvPPN7vhIKlOSnS9XXglezvJoX4Q==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-mask@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-mask/-/plugin-mask-0.6.0.tgz#845b40bb00c66eec15c12c5b2ed970d0837985c2"
+  integrity sha512-zkZVqAA7lxWhkn5EbPjBQ6tPluYIGfLMSX4kD1gksj+MVJJnVAd459AVuEXCvkUvv4wG5AlH8m6ve5NZj9vvxw==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-normalize@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-normalize/-/plugin-normalize-0.6.0.tgz#b1769aef2c89cbde1879c6b43d15b535f2b284c8"
+  integrity sha512-7bNGT+S0rw9gvmxpkNsA19JSqBZYFrAn9QhEmoN4HIimdKtJaoLJh/GnxrPuOBLuv1IPJntoTOOWvOmfrQ6/ww==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-print@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-print/-/plugin-print-0.6.0.tgz#7e0ccdda9718ec2ceabd665eb593f185605d7d5f"
+  integrity sha512-kXNHYo7bGQiMZkUqhCvm6OomjJtZnLGs7cgXp9qsCfPcDBLLW+X3oxnoLaePQMlpQt6hX/lzFnNaWKv/KB1jlA==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+    load-bmfont "^1.4.0"
+
+"@jimp/plugin-resize@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-resize/-/plugin-resize-0.6.0.tgz#d66be57b9bb950e66a6f686c97fbab76bc705af4"
+  integrity sha512-m0AA/mPkJG++RuftBFDUMRenqgIN/uSh88Kqs33VURYaabApni4ML3QslE1TCJtl2Lnu1eosxYlbzODjHx49eg==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-rotate@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-rotate/-/plugin-rotate-0.6.0.tgz#2d7a359b48cc830bf3eee94c9821c2bfd1b27daf"
+  integrity sha512-1QGlIisyxs2HNLuynq/ETc4h7E6At3yR+IYAhG9U4KONG4RqlIy0giyDhnfEZaiqOE+O7f+0Z7zN6GoSHmQjzg==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugin-scale@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugin-scale/-/plugin-scale-0.6.0.tgz#751d0d9ae44aaf9f9b4934bc2a4dd34122cd2894"
+  integrity sha512-le/ttYwYioNPRoMlMaoJMCTv+m8d1v0peo/3J8E6Rf9ok7Bw3agkvjL9ILnsmr8jXj1YLrBSPKRs5nJ6ziM/qA==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+
+"@jimp/plugins@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/plugins/-/plugins-0.6.0.tgz#407581a67891ec6399c1f3ffb95b0fc47c8c502b"
+  integrity sha512-9+znfBJM1B31kvw+IcQFnAuDntQhwca/SONFnKOSZ8BNiQdiuTNbXHFxOo3tvdv1ngtB+LkkiTgK+QoF358b8g==
+  dependencies:
+    "@jimp/plugin-blit" "^0.6.0"
+    "@jimp/plugin-blur" "^0.6.0"
+    "@jimp/plugin-color" "^0.6.0"
+    "@jimp/plugin-contain" "^0.6.0"
+    "@jimp/plugin-cover" "^0.6.0"
+    "@jimp/plugin-crop" "^0.6.0"
+    "@jimp/plugin-displace" "^0.6.0"
+    "@jimp/plugin-dither" "^0.6.0"
+    "@jimp/plugin-flip" "^0.6.0"
+    "@jimp/plugin-gaussian" "^0.6.0"
+    "@jimp/plugin-invert" "^0.6.0"
+    "@jimp/plugin-mask" "^0.6.0"
+    "@jimp/plugin-normalize" "^0.6.0"
+    "@jimp/plugin-print" "^0.6.0"
+    "@jimp/plugin-resize" "^0.6.0"
+    "@jimp/plugin-rotate" "^0.6.0"
+    "@jimp/plugin-scale" "^0.6.0"
+    core-js "^2.5.7"
+    timm "^1.6.1"
+
+"@jimp/png@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/png/-/png-0.6.0.tgz#3eb8a4cd1ff71dc63b1aad5789cf83a3a1508ca1"
+  integrity sha512-DBtMyQyrJxuKI7/1dVqLek+rCMM8U6BSOTHgo05wU7lhJKTB6fn2tbYfsnHQKzd9ld1M2qKuC+O1GTVdB2yl6w==
+  dependencies:
+    "@jimp/utils" "^0.6.0"
+    core-js "^2.5.7"
+    pngjs "^3.3.3"
+
+"@jimp/tiff@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/tiff/-/tiff-0.6.0.tgz#ea65bee43a8ffe972ed9631dabcb9e030acdb004"
+  integrity sha512-PV95CquEsolFziq0zZrAEJIzZSKwMK89TvkOXTPDi/xesgdXGC2rtG1IZFpC9L4UX5hi/M5GaeJa49xULX6Nqw==
+  dependencies:
+    core-js "^2.5.7"
+    utif "^2.0.1"
+
+"@jimp/types@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/types/-/types-0.6.0.tgz#9e9b942fafed4f364f1b999c9f15399b84da7756"
+  integrity sha512-j4tm82huEWpLrwave/2NYnMTY6us/6K9Js6Vd/CHoM/ki8M71tMXEVzc8tly92wtnEzQ9+FEk0Ue6pYo68m/5A==
+  dependencies:
+    "@jimp/bmp" "^0.6.0"
+    "@jimp/gif" "^0.6.0"
+    "@jimp/jpeg" "^0.6.0"
+    "@jimp/png" "^0.6.0"
+    "@jimp/tiff" "^0.6.0"
+    core-js "^2.5.7"
+    timm "^1.6.1"
+
+"@jimp/utils@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@jimp/utils/-/utils-0.6.0.tgz#330ae46adee1cb622fa534fc56fd8a574c9c2d84"
+  integrity sha512-z5iYEfqc45vlYweROneNkjv32en6jS7lPL/eMLIvaEcQAHaoza20Dw8fUoJ0Ht9S92kR74xeTunAZq+gK2w67Q==
+  dependencies:
+    core-js "^2.5.7"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -111,6 +371,11 @@ ansi-styles@^3.0.0:
   integrity sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=
   dependencies:
     color-convert "^1.0.0"
+
+any-base@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/any-base/-/any-base-1.1.0.tgz#ae101a62bc08a597b4c9ab5b7089d456630549fe"
+  integrity sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==
 
 anymatch@^1.3.0:
   version "1.3.0"
@@ -873,11 +1138,6 @@ big.js@^3.1.3:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
   integrity sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=
 
-bignumber.js@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-2.4.0.tgz#838a992da9f9d737e0f4b2db0be62bb09dd0c5e8"
-  integrity sha1-g4qZLan51zfg9LLbC+YrsJ3Qxeg=
-
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
@@ -890,10 +1150,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bmp-js@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.0.3.tgz#64113e9c7cf1202b376ed607bf30626ebe57b18a"
-  integrity sha1-ZBE+nHzxICs3btYHvzBibr5XsYo=
+bmp-js@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"
+  integrity sha1-4Fpj95amwf8l9Hcex62twUjAcjM=
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.7"
@@ -1033,6 +1293,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.1.tgz#dd57fa0f109ac59c602479044dca7b8b3d0b71d6"
+  integrity sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -1268,6 +1536,11 @@ core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
   integrity sha1-TekR5mew6ukSTjQlS1OupvxhjT4=
+
+core-js@^2.5.7:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.0.tgz#1e30793e9ee5782b307e37ffa22da0eacddd84d4"
+  integrity sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1560,11 +1833,6 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-promise@^3.0.2:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
-  integrity sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=
-
 es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
@@ -1750,10 +2018,10 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
-exif-parser@^0.1.9:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/exif-parser/-/exif-parser-0.1.9.tgz#1d087e05fd2b079e3a8eaf8ff249978cb5f6fba7"
-  integrity sha1-HQh+Bf0rB546jq+P8kmXjLX2+6c=
+exif-parser@^0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/exif-parser/-/exif-parser-0.1.12.tgz#58a9d2d72c02c1f6f02a0ef4a9166272b7760922"
+  integrity sha1-WKnS1ywCwfbwKg70qRZicrd2CSI=
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -1831,10 +2099,10 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-type@^3.1.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/file-type/-/file-type-3.9.0.tgz#257a078384d1db8087bc449d107d52a52672b9e9"
-  integrity sha1-JXoHg4TR24CHvESdEH1SpSZyuek=
+file-type@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-9.0.0.tgz#a68d5ad07f486414dfb2c8866f73161946714a18"
+  integrity sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -2306,11 +2574,6 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
-
-ip-regex@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-1.0.3.tgz#dc589076f659f419c222039a33316f1c7387effd"
-  integrity sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2828,32 +3091,21 @@ jest@^20.0.4:
   dependencies:
     jest-cli "^20.0.4"
 
-jimp@^0.2.21:
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/jimp/-/jimp-0.2.28.tgz#dd529a937190f42957a7937d1acc3a7762996ea2"
-  integrity sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=
+jimp@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/jimp/-/jimp-0.6.0.tgz#b0fc278a3313a4136bc9d352e0e81e56eb8c864a"
+  integrity sha512-RYpN+AAlTEMf8Bnkhq2eeTNyr70rDK/2UUfUqzBJmwmZwdR6fxRJvgbCGWT1BDVRxaAqo+4CWm8ePBxOIsr4jg==
   dependencies:
-    bignumber.js "^2.1.0"
-    bmp-js "0.0.3"
-    es6-promise "^3.0.2"
-    exif-parser "^0.1.9"
-    file-type "^3.1.0"
-    jpeg-js "^0.2.0"
-    load-bmfont "^1.2.3"
-    mime "^1.3.4"
-    mkdirp "0.5.1"
-    pixelmatch "^4.0.0"
-    pngjs "^3.0.0"
-    read-chunk "^1.0.1"
-    request "^2.65.0"
-    stream-to-buffer "^0.1.0"
-    tinycolor2 "^1.1.2"
-    url-regex "^3.0.0"
+    "@babel/polyfill" "^7.0.0"
+    "@jimp/custom" "^0.6.0"
+    "@jimp/plugins" "^0.6.0"
+    "@jimp/types" "^0.6.0"
+    core-js "^2.5.7"
 
-jpeg-js@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.2.0.tgz#53e448ec9d263e683266467e9442d2c5a2ef5482"
-  integrity sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII=
+jpeg-js@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.4.tgz#dc2ba501ee3d58b7bb893c5d1fab47294917e7e7"
+  integrity sha512-6IzjQxvnlT8UlklNmDXIJMWxijULjqGrzgqc0OG7YadZdvm7KPQ1j0ehmQQHckgEWOfgpptzcnWgESovxudpTA==
 
 js-tokens@^3.0.0:
   version "3.0.1"
@@ -3004,16 +3256,17 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-load-bmfont@^1.2.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.3.0.tgz#bb7e7c710de6bcafcb13cb3b8c81e0c0131ecbc9"
-  integrity sha1-u358cQ3mvK/LE8s7jIHgwBMey8k=
+load-bmfont@^1.3.1, load-bmfont@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.0.tgz#75f17070b14a8c785fe7f5bee2e6fd4f98093b6b"
+  integrity sha512-kT63aTAlNhZARowaNYcY29Fn/QYkc52M3l6V1ifRcPewg2lvUZDAj7R6dXjOL9D0sict76op3T5+odumDSF81g==
   dependencies:
     buffer-equal "0.0.1"
     mime "^1.3.4"
     parse-bmfont-ascii "^1.0.3"
     parse-bmfont-binary "^1.0.5"
-    parse-bmfont-xml "^1.1.0"
+    parse-bmfont-xml "^1.1.4"
+    phin "^2.9.1"
     xhr "^2.0.1"
     xtend "^4.0.0"
 
@@ -3338,6 +3591,11 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
+omggif@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/omggif/-/omggif-1.0.9.tgz#dcb7024dacd50c52b4d303f04802c91c057c765f"
+  integrity sha1-3LcCTazVDFK00wPwSALJHAV8dl8=
+
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3436,6 +3694,11 @@ p-timeout@^1.1.1:
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.1.1.tgz#d28e9fdf96e328886fbff078f886ad158c53bf6d"
   integrity sha1-0o6f35bjKIhvv/B4+IatFYxTv20=
 
+pako@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
+  integrity sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==
+
 pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
@@ -3462,10 +3725,10 @@ parse-bmfont-binary@^1.0.5:
   resolved "https://registry.yarnpkg.com/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz#d038b476d3e9dd9db1e11a0b0e53a22792b69006"
   integrity sha1-0Di0dtPp3Z2x4RoLDlOiJ5K2kAY=
 
-parse-bmfont-xml@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/parse-bmfont-xml/-/parse-bmfont-xml-1.1.3.tgz#d6b66a371afd39c5007d9f0eeb262a4f2cce7b7c"
-  integrity sha1-1rZqNxr9OcUAfZ8O6yYqTyzOe3w=
+parse-bmfont-xml@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/parse-bmfont-xml/-/parse-bmfont-xml-1.1.4.tgz#015319797e3e12f9e739c4d513872cd2fa35f389"
+  integrity sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==
   dependencies:
     xml-parse-from-string "^1.0.0"
     xml2js "^0.4.5"
@@ -3557,6 +3820,11 @@ performance-now@^0.2.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
   integrity sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
 
+phin@^2.9.1:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/phin/-/phin-2.9.3.tgz#f9b6ac10a035636fb65dfc576aaaa17b8743125c"
+  integrity sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -3574,7 +3842,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pixelmatch@^4.0.0:
+pixelmatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-4.0.2.tgz#8f47dcec5011b477b67db03c243bc1f3085e8854"
   integrity sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=
@@ -3590,6 +3858,11 @@ pngjs@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.2.0.tgz#fc9fcea1a8a375da54a51148019d5abd41dbabde"
   integrity sha1-/J/OoaijddpUpRFIAZ1avUHbq94=
+
+pngjs@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.3.3.tgz#85173703bde3edac8998757b96e5821d0966a21b"
+  integrity sha512-1n3Z4p3IOxArEs1VRXnZ/RXdfEniAUS9jb68g58FIXMNkPJeZd+Qh4Uq7/e0LVxAQGos1eIUrqrt4FpjdnEd+Q==
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -3705,11 +3978,6 @@ rc@^1.1.2, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-read-chunk@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-1.0.1.tgz#5f68cab307e663f19993527d9b589cace4661194"
-  integrity sha1-X2jKswfmY/GZk1J9m1icrORmEZQ=
-
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -3776,6 +4044,11 @@ regenerator-runtime@^0.10.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
   integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
+regenerator-runtime@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+  integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
@@ -3836,7 +4109,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.65.0, request@^2.79.0, request@^2.81.0:
+request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   integrity sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=
@@ -4133,18 +4406,6 @@ stream-http@^2.3.1:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
-stream-to-buffer@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-to-buffer/-/stream-to-buffer-0.1.0.tgz#26799d903ab2025c9bd550ac47171b00f8dd80a9"
-  integrity sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=
-  dependencies:
-    stream-to "~0.2.0"
-
-stream-to@~0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/stream-to/-/stream-to-0.2.2.tgz#84306098d85fdb990b9fa300b1b3ccf55e8ef01d"
-  integrity sha1-hDBgmNhf25kLn6MAsbPM9V6O8B0=
-
 string-length@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
@@ -4315,7 +4576,12 @@ timers-browserify@^2.0.2:
   dependencies:
     setimmediate "^1.0.4"
 
-tinycolor2@^1.1.2:
+timm@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/timm/-/timm-1.6.1.tgz#5f8aafc932248c76caf2c6af60542a32d3c30701"
+  integrity sha512-hqDTYi/bWuDxL2i6T3v6nrvkAQ/1Bc060GSkVEQZp02zTSTB4CHSKsOkliequCftQaNRcjRqUZmpGWs5FfhrNg==
+
+tinycolor2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
   integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
@@ -4432,13 +4698,6 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
-url-regex@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-3.2.0.tgz#dbad1e0c9e29e105dd0b1f09f6862f7fdb482724"
-  integrity sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=
-  dependencies:
-    ip-regex "^1.0.1"
-
 url-to-options@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
@@ -4463,6 +4722,13 @@ user-home@^2.0.0:
   integrity sha1-nHC/2Babwdy/SGBODwS4tJzenp8=
   dependencies:
     os-homedir "^1.0.0"
+
+utif@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/utif/-/utif-2.0.1.tgz#9e1582d9bbd20011a6588548ed3266298e711759"
+  integrity sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==
+  dependencies:
+    pako "^1.0.5"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Hey I maintain jimp. I did two things

1. update it. lots of bugs have been squashed since the last installed update!
2. switched the resize method to use jimp.RESIZE_BEZIER. This produces a better result with images that have gradients

for example without using jimp.RESIZE_BEZIER some of my images look like 

<img width="1018" alt="screen shot 2018-12-07 at 12 25 36 am" src="https://user-images.githubusercontent.com/1192452/49636183-b6245a80-f9b6-11e8-82d1-4a53347a4a7a.png">

but if i switch to jimp.RESIZE_BEZIER i get

<img width="1040" alt="screen shot 2018-12-07 at 12 38 51 am" src="https://user-images.githubusercontent.com/1192452/49636820-88401580-f9b8-11e8-9d7f-c7c5234ca44b.png">

tries:
RESIZE_NEAREST_NEIGHBOR - fixes issues but shaky lines
RESIZE_BILINEAR - solid black line
RESIZE_HERMITE - good but text slightly shakey

Another good options would be to allow the user to pass in the resize mode as an option. @herrstucki thoughts?
