### PR TITLE
use '100% 100%' instead of 'cover' ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,16 @@ ReactDOM.render(
   <div style={{
     height: responsiveImage.height,
     width: responsiveImage.width,
-    backgroundSize: 'cover',
+    backgroundSize: '100% 100%',
     backgroundImage: 'url("' + responsiveImage.placeholder + '")'
   }}>
     <img src={responsiveImage.src} srcSet={responsiveImage.srcSet} />
   </div>, el);
 ```
 
+**Tip:** The placeholder will have a slightly different height/width-ratio due to the reduced resolution. 
+Background size *'100% 100%'* will scale it to the height and width of the original image provided to the attributes `height` and `width` of the `div` element.
+The background size *'cover'* would show a slightly enlarged and cropped placeholder that would show a little bit more flicker once the original image is loaded by the `img` element.
 
 ### Options
 


### PR DESCRIPTION
to avoid cropping due to changed aspect ratio of preview. 

I added a paragraph to describe the difference of '100% 100%' vs. 'cover'. Please adjust the text if you think this is not clear enough.