### PR TITLE
Move background function to relevant operations

### DIFF
--- a/src/adapters/sharp.js
+++ b/src/adapters/sharp.js
@@ -13,8 +13,9 @@ module.exports = (imagePath: string) => {
           .resize(width, null);
 
         if (options.background) {
-          resized = resized.background(options.background)
-          .flatten();
+          resized = resized.flatten({
+            background: options.background
+          });
         }
 
         if (mime === 'image/jpeg') {


### PR DESCRIPTION
Replace the deprecated `background()` function with a separate option of the `flatten()` operation. This ensures compatibility with sharp v0.22.0.

References:
- https://github.com/lovell/sharp/issues/1392
- https://sharp.pixelplumbing.com/en/stable/changelog/#v0220-18th-march-2019