### PR TITLE
Sharp: Preserve EXIF Orientation (eg, portrait)

### DIFF
--- a/src/adapters/sharp.js
+++ b/src/adapters/sharp.js
@@ -41,6 +41,9 @@ module.exports = (imagePath: string) => {
           });
         }
 
+        // .toBuffer() strips EXIF data, including orientation (eg, portrait)
+        resized = resized.rotate();
+
         resized.toBuffer((err, data, { height }) => {
           if (err) {
             reject(err);

--- a/src/adapters/sharp.js
+++ b/src/adapters/sharp.js
@@ -41,7 +41,9 @@ module.exports = (imagePath: string) => {
           });
         }
 
-        // .toBuffer() strips EXIF data, including orientation (eg, portrait)
+        // .toBuffer() strips EXIF metadata like orientation, so portrait
+        // images will become landscape. This updates the image to reflect 
+        // the EXIF metadata (if an EXIF orientation is set; otherwise unchanged).
         resized = resized.rotate();
 
         resized.toBuffer((err, data, { height }) => {


### PR DESCRIPTION
With sharp.js, invoking [.toBuffer()](https://sharp.pixelplumbing.com/api-output#tobuffer) drops the EXIF metadata from the image. This means that portrait photos will revert back to landscape, as the EXIF Orientation attribute is no longer present. Calling [.rotate()](https://sharp.pixelplumbing.com/api-operation#rotate) without an argument, implicitly `auto`, updates the image pixel data based on the EXIF Orientation.

This only rotates images with a portrait EXIF orientation or similar. Most images will be unchanged by this -- the landscape and square photos below are unchanged. I think this is mainly a digital camera thing.

<img width="1322" alt="Ted_Pennings_and_Ted_Pennings" src="https://user-images.githubusercontent.com/310323/93727601-addbe600-fb70-11ea-857a-5a3679fd2b36.png">
