### PR TITLE
Adds missing peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
   "peerDependencies": {
     "webpack": "^4.0.0 || ^5.0.0"
   },
+  "peerDependenciesMeta": {
+    "sharp": {
+      "optional": true
+    },
+  },
   "dependencies": {
     "loader-utils": "^2.0.0",
     "schema-utils": "^3.0.0"


### PR DESCRIPTION
This loader is missing an *optional* peer dependency on `sharp`, causing errors to be reported in some environments. This diff fixes that by making use of the [`peerDependenciesMeta` field](https://yarnpkg.com/configuration/manifest#peerDependenciesMeta.optional).