### PR TITLE
Adds missing peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
   "peerDependencies": {
     "webpack": "^4.0.0 || ^5.0.0"
   },
+  "peerDependenciesMeta": {
+    "jimp": {
+      "optional": true
+    },
+    "sharp": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "loader-utils": "^2.0.0",
     "schema-utils": "^3.0.0"


### PR DESCRIPTION
Fixes #114 - this way the packages are properly loaded from whatever version the parent package provides, but don't emit warnings if missing.