### PR TITLE
Fix readme code typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ module.exports = {
     rules: [
       {
         test: /\.(jpe?g|png|webp)$/i,
-        use: [
+        use: {
           loader: 'responsive-loader',
           options: {
 +           adapter: require('responsive-loader/sharp')
           }
-        ]
+        }
       }
     ]
   },


### PR DESCRIPTION
Found a tiny code typo in the readme: in the "With sharp" section, square brackets were used where curly brackets should be.

Thanks for the awesome loader!