### PR TITLE
Adding missing dependency on make-dir.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "@types/node": "^17.0.39",
     "find-cache-dir": "^3.3.2",
     "json5": "^2.2.1",
-    "schema-utils": "^4.0.0"
+    "schema-utils": "^4.0.0",
+    "make-dir": "3.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "find-cache-dir": "^3.3.2",
     "json5": "^2.2.1",
     "schema-utils": "^4.0.0",
-    "make-dir": "3.1.0"
+    "make-dir": "^3.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.2",


### PR DESCRIPTION
Seems like `make-dir`, which is used [in the cache](https://github.com/dazuaz/responsive-loader/blob/5ed6350d1b8227717d3505baa0e9f6801930b243/src/cache.ts#L15), is not specified in the `package.json`, so it is not installed when installing `responsive-loader`. Just experienced this error on Node v16.14.2 and npm 8.5.0 with `responsive-loader@3.0.3`.