### PR TITLE
add support png for sharp

### DIFF
--- a/src/adapters/sharp.ts
+++ b/src/adapters/sharp.ts
@@ -40,6 +40,12 @@ class SharpAdapter {
           progressive: options.progressive,
         })
       }
+      if (mime === 'image/png') {
+        resized = resized.png({
+          quality: options.quality,
+          progressive: options.progressive,
+        })
+      }
       if (mime === 'image/webp') {
         resized = resized.webp({
           quality: options.quality,


### PR DESCRIPTION
https://sharp.pixelplumbing.com/changelog#v0280---29th-march-2021

Prebuilt binaries now include mozjpeg and libimagequant (BSD 2-Clause).